### PR TITLE
Replace positions model from Positions to PositionHist

### DIFF
--- a/lib/rest2.js
+++ b/lib/rest2.js
@@ -1075,7 +1075,7 @@ class RESTv2 {
    */
   generateToken ({ ttl, scope, writePermission } = {}, cb) {
     return this._makeAuthRequest('/auth/w/token', {
-      ttl, scope, writePermission,
+      ttl, scope, writePermission
     }, cb)
   }
 }

--- a/lib/rest2.js
+++ b/lib/rest2.js
@@ -12,7 +12,6 @@ const {
   FundingTrade,
   MarginInfo,
   Order,
-  Position,
   PositionHist,
   Trade,
   PublicTrade,
@@ -669,7 +668,7 @@ class RESTv2 {
    * @see https://docs.bitfinex.com/v2/reference#rest-auth-positions
    */
   positions (cb) {
-    return this._makeAuthRequest('/auth/r/positions', {}, cb, Position)
+    return this._makeAuthRequest('/auth/r/positions', {}, cb, PositionHist)
   }
 
   /**

--- a/lib/rest2.js
+++ b/lib/rest2.js
@@ -12,7 +12,7 @@ const {
   FundingTrade,
   MarginInfo,
   Order,
-  PositionHist,
+  Position,
   Trade,
   PublicTrade,
   TradingTicker,
@@ -668,7 +668,7 @@ class RESTv2 {
    * @see https://docs.bitfinex.com/v2/reference#rest-auth-positions
    */
   positions (cb) {
-    return this._makeAuthRequest('/auth/r/positions', {}, cb, PositionHist)
+    return this._makeAuthRequest('/auth/r/positions', {}, cb, Position)
   }
 
   /**
@@ -682,7 +682,7 @@ class RESTv2 {
   positionsHistory (start = 0, end = Date.now(), limit = 50, cb) {
     return this._makeAuthRequest('/auth/r/positions/hist', {
       start, end, limit
-    }, cb, PositionHist)
+    }, cb, Position)
   }
 
   /**
@@ -697,7 +697,7 @@ class RESTv2 {
   positionsAudit (id = [], start = 0, end = Date.now(), limit = 250, cb) {
     return this._makeAuthRequest('/auth/r/positions/audit', {
       id, start, end, limit
-    }, cb, PositionHist)
+    }, cb, Position)
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-api-node-rest",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Official Bitfinex REST v1 & v2 API interfaces",
   "engines": {
     "node": ">=7"


### PR DESCRIPTION
This PR replaces positions model from `Positions` to `PositionHist` because now positions are returned data structure as same as `positionsHistory`

### Dependencies:
* This PR depends on this PR: [bitfinexcom/bfx-api-node-models#15](https://github.com/bitfinexcom/bfx-api-node-models/pull/15)