### PR TITLE
Add Status messages endpoint

### DIFF
--- a/doc/rest2.md
+++ b/doc/rest2.md
@@ -8,6 +8,7 @@ Communicates with v2 of the Bitfinex HTTP API
 * [RESTv2](#RESTv2)
     * [new RESTv2(opts)](#new_RESTv2_new)
     * [.status(cb)](#RESTv2+status) ⇒ <code>Promise</code>
+    * [.statusMessages(type, keys, cb)](#RESTv2+statusMessages) ⇒ <code>Promise</code>
     * [.ticker(symbol, cb)](#RESTv2+ticker) ⇒ <code>Promise</code>
     * [.tickers(symbols, cb)](#RESTv2+tickers) ⇒ <code>Promise</code>
     * [.tickersHistory(symbols, start, end, limit, cb)](#RESTv2+tickersHistory) ⇒ <code>Promise</code>
@@ -85,6 +86,20 @@ Instantiate a new REST v2 transport.
 | Param | Type |
 | --- | --- |
 | cb | <code>Method</code> |
+
+
+<a name="RESTv2+statusMessages"></a>
+
+### resTv2.statusMessages(type, keys, cb) ⇒ <code>Promise</code>
+**Kind**: instance method of <code>[RESTv2](#RESTv2)</code>  
+**Returns**: <code>Promise</code> - p  
+**See**: https://docs.bitfinex.com/v2/reference#[PUBLICATION PENDING]
+
+| Param | Type | Default |
+| --- | --- | --- |
+| type | <code>string</code> | <code>&quot;deriv&quot;</code> |
+| keys | <code>Array [string]</code> | <code>[&quot;ALL&quot;]</code> |
+| cb | <code>Method</code> |  |
 
 <a name="RESTv2+ticker"></a>
 

--- a/doc/rest2.md
+++ b/doc/rest2.md
@@ -93,7 +93,7 @@ Instantiate a new REST v2 transport.
 ### resTv2.statusMessages(type, keys, cb) ⇒ <code>Promise</code>
 **Kind**: instance method of <code>[RESTv2](#RESTv2)</code>  
 **Returns**: <code>Promise</code> - p  
-**See**: https://docs.bitfinex.com/v2/reference#[PUBLICATION PENDING]
+**See**: https://docs.bitfinex.com/v2/reference#status
 
 | Param | Type | Default |
 | --- | --- | --- |

--- a/lib/rest2.js
+++ b/lib/rest2.js
@@ -355,7 +355,7 @@ class RESTv2 {
    * @param {string[]} keys
    * @param {Method?} cb
    * @return {Promise} p
-   * @see https://docs.bitfinex.com/v2/[PUBLICATION PENDING]
+   * @see https://docs.bitfinex.com/v2/reference#status
    */
   statusMessages (type = 'deriv', keys = ['ALL'], cb) {
     const url = `/status/${type}?keys=${keys.join(',')}`

--- a/lib/rest2.js
+++ b/lib/rest2.js
@@ -27,7 +27,8 @@ const {
   Movement,
   LedgerEntry,
   UserInfo,
-  Currency
+  Currency,
+  StatusMessagesDeriv
 } = require('bfx-api-node-models')
 
 const RESTv1 = require('./rest1')
@@ -347,6 +348,20 @@ class RESTv2 {
    */
   status (cb = () => {}) {
     return this._makePublicRequest('/platform/status', cb)
+  }
+
+  /**
+   * @param {string?} type
+   * @param {string[]} keys
+   * @param {Method?} cb
+   * @return {Promise} p
+   * @see https://docs.bitfinex.com/v2/[PUBLICATION PENDING]
+   */
+  statusMessages (type = 'deriv', keys = ['ALL'], cb) {
+    const url = `/status/${type}?keys=${keys.join(',')}`
+    const transformer = (type === 'deriv') ? StatusMessagesDeriv : null
+
+    return this._makePublicRequest(url, cb, transformer)
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-api-node-rest",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Official Bitfinex REST v1 & v2 API interfaces",
   "engines": {
     "node": ">=7"

--- a/test/lib/rest-2-integration.js
+++ b/test/lib/rest-2-integration.js
@@ -97,6 +97,7 @@ describe('RESTv2 integration (mock server) tests', () => {
     ['tickersHistory', 'tickers_hist', [['tBTCUSD', 'tETHUSD'], 'start', 'end', 'limit']],
     ['stats', 'stats.key.context', ['key', 'context']],
     ['candles', 'candles.trade:30m:tBTCUSD.hist', [{ timeframe: '30m', symbol: 'tBTCUSD', section: 'hist' }]],
+    ['statusMessages', 'status_messages.deriv.ALL', ['deriv', ['ALL']]],
 
     // private
     ['alertList', 'alerts.price', ['price']],


### PR DESCRIPTION
Add status message endpoint, depends on https://github.com/bitfinexcom/bfx-api-node-models/pull/22
Required for tests: https://github.com/bitfinexcom/bfx-api-mock-srv/pull/20