### PR TITLE
Add new v2 endpoints

### DIFF
--- a/lib/rest2.js
+++ b/lib/rest2.js
@@ -29,7 +29,8 @@ const {
   Liquidations,
   UserInfo,
   Currency,
-  StatusMessagesDeriv
+  StatusMessagesDeriv,
+  Notification
 } = require('bfx-api-node-models')
 
 const RESTv1 = require('./rest1')
@@ -112,6 +113,11 @@ class RESTv2 {
     }).then((data) => {
       return this._response(data, transformer, cb)
     })
+  }
+
+  _takeNotificationInfo (data) {
+    const notification = new Notification(data)
+    return notification.notifyInfo
   }
 
   /**
@@ -229,10 +235,10 @@ class RESTv2 {
     if (!ModelClass || !this._transform) return data
 
     if (Array.isArray(data[0])) {
-      return data.map(row => new ModelClass(row))
+      return data.map(row => new ModelClass(row, this))
     }
 
-    return new ModelClass(data)
+    return new ModelClass(data, this)
   }
 
   /**
@@ -997,74 +1003,6 @@ class RESTv2 {
   }
 
   /**
-   * Request a deposit address
-   *
-   * @param {Object} params
-   * @param {string} params.request
-   * @param {string} params.nonce
-   * @param {string} params.method - name of currency
-   * @param {string} params.wallet_name - 'trading', 'exchange' or 'deposit'
-   * @param {number} params.renew - 1 or 0
-   * @param {Method} cb
-   * @return {Promise} p
-   * @deprecated
-   * @see https://docs.bitfinex.com/v1/reference#rest-auth-deposit
-   */
-  deposit (params, cb) {
-    return this._makeAuthLegacyRequest('deposit/new', params, cb)
-  }
-
-  /**
-   * Requests a withdrawl from a wallet
-   *
-   * @param {Object} params
-   * @param {string} params.withdraw_type - name of currency
-   * @param {string} params.walletselected - 'trading', 'exchange, or 'deposit'
-   * @param {string} params.amount
-   * @param {string} params.address
-   * @param {string} params.payment_id - optional, for monero
-   * @param {string} params.account_name
-   * @param {string} params.account_number
-   * @param {string} params.swift
-   * @param {string} params.bank_name
-   * @param {string} params.bank_address
-   * @param {string} params.bank_city
-   * @param {string} params.bank_country
-   * @param {string} params.detail_payment - message to beneficiary
-   * @param {number} params.expressWire - 1 or 0
-   * @param {string} params.intermediary_bank_name
-   * @param {string} params.intermediary_bank_address
-   * @param {string} params.intermediary_bank_city
-   * @param {string} params.intermediary_bank_country
-   * @param {string} params.intermediary_bank_account
-   * @param {string} params.intermediary_bank_swift
-   * @param {Method} cb
-   * @return {Promise} p
-   * @deprecated
-   * @see https://docs.bitfinex.com/v1/reference#rest-auth-withdrawal
-   */
-  withdraw (params, cb) {
-    return this._makeAuthLegacyRequest('withdraw', params, cb)
-  }
-
-  /**
-   * Execute a balance transfer between wallets
-   *
-   * @param {Object} params
-   * @param {number} params.amount - amount to transfer
-   * @param {string} params.currency - currency of funds to transfer
-   * @param {string} params.walletFrom - wallet to transfer from
-   * @param {string} params.walletTo - wallet to transfer to
-   * @param {Method} cb
-   * @return {Promise} p
-   * @deprecated
-   * @see https://docs.bitfinex.com/v1/reference#rest-auth-transfer-between-wallets
-   */
-  transfer (params, cb) {
-    return this.make_request('transfer', params, cb)
-  }
-
-  /**
    * Fetch the permissions of the key being used to generate this request
    *
    * @param {Method} cb
@@ -1086,19 +1024,6 @@ class RESTv2 {
    */
   balances (cb) {
     return this._makeAuthLegacyRequest('balances', {}, cb)
-  }
-
-  /**
-   * @param {Object} params
-   * @param {number} params.position_id
-   * @param {number} params.amount
-   * @param {Method} cb
-   * @return {Promise} p
-   * @deprecated
-   * @see https://docs.bitfinex.com/v1/reference#rest-auth-claim-position
-   */
-  claimPosition (params, cb) {
-    return this._makeAuthLegacyRequest('positions/claim', params, cb)
   }
 
   /**
@@ -1166,6 +1091,156 @@ class RESTv2 {
     return this._makeAuthRequest('/auth/w/token', {
       ttl, scope, writePermission
     }, cb)
+  }
+
+  /**
+   * Submit new order
+   *
+   * @param {Order} order - models.Order
+   * @param {Method} cb
+   */
+  submitOrder (order, cb) {
+    return this._makeAuthRequest('/auth/w/order/submit', order.toNewOrderPacket(), cb)
+      .then((res) => {
+        const notification = new Notification(res)
+        // 2 orders can be returned if OCO was used. But due to the interface
+        // we can only return one. User should use getOrders instead
+        return notification.notifyInfo[0] || []
+      })
+  }
+
+  /**
+   * Update existing order
+   *
+   * @param {Objet} order - updates to order
+   * @param {Method} cb
+   */
+  updateOrder (changes, cb) {
+    return this._makeAuthRequest('/auth/w/order/update', changes, cb)
+      .then(this._takeNotificationInfo)
+  }
+
+  /**
+   * Cancel existing order
+   *
+   * @param {int} id - order id
+   * @param {Method} cb
+   */
+  cancelOrder (id, cb) {
+    return this._makeAuthRequest('/auth/w/order/cancel', { id }, cb)
+      .then((res) => {
+        const notification = new Notification(res)
+        return notification.notifyInfo
+      })
+  }
+
+  submitOrderMulti () {
+    return Promise.reject("Not implemented - requires work on WS as well")
+  }
+
+  /**
+   * Claim existing open position
+   *
+   * @param {int} id - position id
+   * @param {Method} cb
+   */
+  claimPosition (id, cb) {
+    return this._makeAuthRequest('/auth/w/position/claim', { id }, cb)
+      .then(this._takeNotificationInfo)
+  }
+
+  /**
+   * Submit new funding offer
+   *
+   * @param {Object} offer - models.Offer
+   * @param {Method} cb
+   */
+  submitFundingOffer (offer, cb) {
+    return this._makeAuthRequest('/auth/w/funding/offer/submit', offer.toNewOfferPacket(), cb)
+      .then(this._takeNotificationInfo)
+  }
+
+  /**
+   * Cancel existing funding offer
+   *
+   * @param {int} id - offer id
+   * @param {Method} cb
+   */
+  cancelFundingOffer (id, cb) {
+    return this._makeAuthRequest('/auth/w/funding/offer/cancel', { id }, cb)
+      .then(this._takeNotificationInfo)
+  }
+
+  /**
+   * Close funding
+   *
+   * @param {Object} params
+   * @param {int} param.id - funding id
+   * @param {string} param.type - funding type LIMIT | FRRDELTAVAR
+   * @param {*} cb
+   */
+  closeFunding (params, cb) {
+    return this._makeAuthRequest('/auth/w/funding/close', params, cb)
+      .then(this._takeNotificationInfo)
+  }
+
+  /**
+   * Submit automatic funding
+   *
+   * @param {Object} params
+   * @param {int} params.status
+   * @param {string} params.currency - currency i.e fUSD
+   * @param {number} params.amount - amount to borrow/lend
+   * @param {number} params.rate - if == 0 then FRR is used
+   * @param {int} params.period - time the offer remains locked in for
+   * @param {*} cb
+   */
+  submitAutoFunding (params, cb) {
+    return this._makeAuthRequest('/auth/w/funding/auto', params, cb)
+      .then(this._takeNotificationInfo)
+  }
+
+  /**
+   * Execute a balance transfer between wallets
+   *
+   * @param {number} params.amount - amount to transfer
+   * @param {string} params.from - wallet from
+   * @param {string} params.to - wallet to
+   * @param {string} params.currency - currency from
+   * @param {string} params.currencyTo - currency to
+   * @param {Method} cb
+   * @return {Promise} p
+   */
+  transfer (params, cb) {
+    params.currency_to = params.currencyTo
+    return this._makeAuthRequest('/auth/w/funding/auto', params, cb)
+      .then(this._takeNotificationInfo)
+  }
+
+  /**
+   * @param {Object} params
+   * @param {string} wallet - wallet i.e exchange, margin
+   * @param {string} method - protocol method i.e bitcoin, tetherus
+   * @param {int} opRenew - if 1 then generates a new address
+   * @param {*} cb
+   */
+  getDepositAddress (params, cb) {
+    params.op_renew = params.opRenew
+    return this._makeAuthRequest('/auth/w/deposit/address', params, cb)
+      .then(this._takeNotificationInfo)
+  }
+
+  /**
+   * @param {object} params
+   * @param {string} wallet - wallet i.e exchange, margin
+   * @param {string} method - protocol method i.e bitcoin, tetherus
+   * @param {number} amount - amount to withdraw
+   * @param {string} address - destination address
+   * @param {*} cb
+   */
+  withdraw (cb) {
+    return this._makeAuthRequest('/v2/auth/w/withdraw', params, cb)
+      .then(this._takeNotificationInfo)
   }
 }
 

--- a/lib/rest2.js
+++ b/lib/rest2.js
@@ -5,7 +5,7 @@ const rp = require('request-promise')
 const Promise = require('bluebird')
 const _isEmpty = require('lodash/isEmpty')
 const { URLSearchParams } = require('url')
-const { genAuthSig, nonce, isClass } = require('bfx-api-node-util')
+const { genAuthSig, nonce, isClass, takeResNotifyInfo } = require('bfx-api-node-util')
 const {
   FundingCredit,
   FundingLoan,
@@ -113,11 +113,6 @@ class RESTv2 {
     }).then((data) => {
       return this._response(data, transformer, cb)
     })
-  }
-
-  _takeNotificationInfo (data) {
-    const notification = new Notification(data)
-    return notification.notifyInfo
   }
 
   /**
@@ -1102,10 +1097,9 @@ class RESTv2 {
   submitOrder (order, cb) {
     return this._makeAuthRequest('/auth/w/order/submit', order.toNewOrderPacket(), cb)
       .then((res) => {
-        const notification = new Notification(res)
         // 2 orders can be returned if OCO was used. But due to the interface
         // we can only return one. User should use getOrders instead
-        return notification.notifyInfo[0] || []
+        return takeResNotifyInfo(res)[0] || []
       })
   }
 
@@ -1117,7 +1111,7 @@ class RESTv2 {
    */
   updateOrder (changes, cb) {
     return this._makeAuthRequest('/auth/w/order/update', changes, cb)
-      .then(this._takeNotificationInfo)
+      .then(takeResNotifyInfo)
   }
 
   /**
@@ -1128,10 +1122,7 @@ class RESTv2 {
    */
   cancelOrder (id, cb) {
     return this._makeAuthRequest('/auth/w/order/cancel', { id }, cb)
-      .then((res) => {
-        const notification = new Notification(res)
-        return notification.notifyInfo
-      })
+    .then(takeResNotifyInfo)
   }
 
   submitOrderMulti () {
@@ -1146,7 +1137,7 @@ class RESTv2 {
    */
   claimPosition (id, cb) {
     return this._makeAuthRequest('/auth/w/position/claim', { id }, cb)
-      .then(this._takeNotificationInfo)
+      .then(takeResNotifyInfo)
   }
 
   /**
@@ -1157,7 +1148,7 @@ class RESTv2 {
    */
   submitFundingOffer (offer, cb) {
     return this._makeAuthRequest('/auth/w/funding/offer/submit', offer.toNewOfferPacket(), cb)
-      .then(this._takeNotificationInfo)
+      .then(takeResNotifyInfo)
   }
 
   /**
@@ -1168,7 +1159,7 @@ class RESTv2 {
    */
   cancelFundingOffer (id, cb) {
     return this._makeAuthRequest('/auth/w/funding/offer/cancel', { id }, cb)
-      .then(this._takeNotificationInfo)
+      .then(takeResNotifyInfo)
   }
 
   /**
@@ -1181,7 +1172,7 @@ class RESTv2 {
    */
   closeFunding (params, cb) {
     return this._makeAuthRequest('/auth/w/funding/close', params, cb)
-      .then(this._takeNotificationInfo)
+      .then(takeResNotifyInfo)
   }
 
   /**
@@ -1197,7 +1188,7 @@ class RESTv2 {
    */
   submitAutoFunding (params, cb) {
     return this._makeAuthRequest('/auth/w/funding/auto', params, cb)
-      .then(this._takeNotificationInfo)
+      .then(takeResNotifyInfo)
   }
 
   /**
@@ -1214,7 +1205,7 @@ class RESTv2 {
   transfer (params, cb) {
     params.currency_to = params.currencyTo
     return this._makeAuthRequest('/auth/w/funding/auto', params, cb)
-      .then(this._takeNotificationInfo)
+      .then(takeResNotifyInfo)
   }
 
   /**
@@ -1227,7 +1218,7 @@ class RESTv2 {
   getDepositAddress (params, cb) {
     params.op_renew = params.opRenew
     return this._makeAuthRequest('/auth/w/deposit/address', params, cb)
-      .then(this._takeNotificationInfo)
+      .then(takeResNotifyInfo)
   }
 
   /**
@@ -1240,7 +1231,7 @@ class RESTv2 {
    */
   withdraw (params, cb) {
     return this._makeAuthRequest('/v2/auth/w/withdraw', params, cb)
-      .then(this._takeNotificationInfo)
+      .then(takeResNotifyInfo)
   }
 }
 

--- a/lib/rest2.js
+++ b/lib/rest2.js
@@ -1135,7 +1135,7 @@ class RESTv2 {
   }
 
   submitOrderMulti () {
-    return Promise.reject("Not implemented - requires work on WS as well")
+    return Promise.reject(new Error('Not implemented - requires work on WS as well'))
   }
 
   /**
@@ -1238,7 +1238,7 @@ class RESTv2 {
    * @param {string} address - destination address
    * @param {*} cb
    */
-  withdraw (cb) {
+  withdraw (params, cb) {
     return this._makeAuthRequest('/v2/auth/w/withdraw', params, cb)
       .then(this._takeNotificationInfo)
   }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "standard": "^14.1.0"
   },
   "dependencies": {
-    "bfx-api-node-models": "git+http://github.com/bitfinexcom/bfx-api-node-models.git#semver:^1.0.12",
+    "bfx-api-node-models": "git+http://github.com/bitfinexcom/bfx-api-node-models.git#semver:^1.1.0",
     "bfx-api-node-util": "git+http://github.com/bitfinexcom/bfx-api-node-util.git#semver:^1.0.2",
     "bluebird": "^3.5.5",
     "copy": "^0.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-api-node-rest",
-  "version": "1.1.4",
+  "version": "2.0.0",
   "description": "Official Bitfinex REST v1 & v2 API interfaces",
   "engines": {
     "node": ">=7"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "bfx-api-node-models": "git+http://github.com/bitfinexcom/bfx-api-node-models.git#semver:^1.1.0",
-    "bfx-api-node-util": "git+http://github.com/bitfinexcom/bfx-api-node-util.git#semver:^1.0.2",
+    "bfx-api-node-util": "git+http://github.com/bitfinexcom/bfx-api-node-util.git#semver:^1.0.4",
     "bluebird": "^3.5.5",
     "copy": "^0.3.2",
     "debug": "^4.1.1",


### PR DESCRIPTION
### Description:
Adds new V2 endpoints, see parent pr: https://github.com/bitfinexcom/bitfinex-api-node/pull/502

### Breaking changes:
Required bump of major version: see PR description for https://github.com/bitfinexcom/bitfinex-api-node/pull/502

### New features:
- [x] `rest2.withdraw`
- [x] `rest2.getDepositAddress`
- [x] `rest2.transfer`
- [x] `rest2.submitAutoFunding`
- [x] `rest2.closeFunding`
- [x] `rest2.cancelFundingOffer`
- [x] `rest2.submitFundingOffer`
- [x] `rest2.claimPosition`
- [x] `rest2.cancelOrder`
- [x] `rest2.updateOrder`
- [x] `rest2.submitOrder`


### Fixes:
None

### PR status:
- [x] Version bumped
- [x] Change-log updated
- [ ] Tests added or updated
