### PR TITLE
hotfix: v2/rest/withdraw use correct url

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+# 2.0.4
+- v2/rest/withdraw invalid url hotfix
+
 # 2.0.3
 - manifest: switch to npm reg deps for bfx modules
 - readme: minor edit

--- a/lib/rest2.js
+++ b/lib/rest2.js
@@ -1240,7 +1240,7 @@ class RESTv2 {
    * @param {*} cb
    */
   withdraw (params, cb) {
-    return this._makeAuthRequest('/v2/auth/w/withdraw', params, cb)
+    return this._makeAuthRequest('/auth/w/withdraw', params, cb)
       .then(this._takeResNotifyInfo)
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-api-node-rest",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Official Bitfinex REST v1 & v2 API interfaces",
   "engines": {
     "node": ">=7"


### PR DESCRIPTION
### Description:
Currently the rest withdraw function uses the wrong url. This pr fixes that.

### Breaking changes:
None

### New features:
None

### Fixes:
- [x] Withdraw use correct url 

### PR status:
- [x] Version bumped
- [x] Change-log updated
