### PR TITLE
Hotfix takeres

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+# 2.0.8
+- Hotfix: _takeResNotifyInfo return all notification info
+
 # 2.0.7
 - Fix: submitFundingOffer
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
-# 2.0.8
+
+# 3.0.0
 - Hotfix: _takeResNotifyInfo return all notification info
+- restv2.withdraw returns notfication instead of just info
 
 # 2.0.7
 - Fix: submitFundingOffer

--- a/lib/rest2.js
+++ b/lib/rest2.js
@@ -39,13 +39,12 @@ const BASE_TIMEOUT = 15000
 const API_URL = 'https://api.bitfinex.com'
 
 /**
- * Parses response into notification object and then
- * extracts the info element
+ * Parses response into notification object
  * @param {Object} Notification.notify_info
  */
-function takeResNotifyInfo (data) {
+function _takeResNotify (data) {
   const notification = new Notification(data)
-  return { ...notification.notifyInfo, notification }
+  return notification
 }
 
 /**
@@ -1122,7 +1121,8 @@ class RESTv2 {
       .then((res) => {
         // 2 orders can be returned if OCO was used. But due to the interface
         // we can only return one. User should use getOrders instead
-        return takeResNotifyInfo(res)[0] || []
+        const orders = _takeResNotify(res).notifyInfo || []
+        return orders[0] || []
       })
   }
 
@@ -1134,7 +1134,7 @@ class RESTv2 {
    */
   updateOrder (changes, cb) {
     return this._makeAuthRequest('/auth/w/order/update', changes, cb)
-      .then(takeResNotifyInfo)
+      .then(_takeResNotify)
   }
 
   /**
@@ -1145,7 +1145,7 @@ class RESTv2 {
    */
   cancelOrder (id, cb) {
     return this._makeAuthRequest('/auth/w/order/cancel', { id }, cb)
-      .then(takeResNotifyInfo)
+      .then(_takeResNotify)
   }
 
   submitOrderMulti () {
@@ -1160,7 +1160,7 @@ class RESTv2 {
    */
   claimPosition (id, cb) {
     return this._makeAuthRequest('/auth/w/position/claim', { id }, cb)
-      .then(takeResNotifyInfo)
+      .then(_takeResNotify)
   }
 
   /**
@@ -1181,7 +1181,7 @@ class RESTv2 {
     }
 
     return this._makeAuthRequest('/auth/w/funding/offer/submit', packet, cb)
-      .then(takeResNotifyInfo)
+      .then(_takeResNotify)
   }
 
   /**
@@ -1192,7 +1192,7 @@ class RESTv2 {
    */
   cancelFundingOffer (id, cb) {
     return this._makeAuthRequest('/auth/w/funding/offer/cancel', { id }, cb)
-      .then(takeResNotifyInfo)
+      .then(_takeResNotify)
   }
 
   /**
@@ -1204,7 +1204,7 @@ class RESTv2 {
    */
   cancelAllFundingOffers (params, cb) {
     return this._makeAuthRequest('/auth/w/funding/offer/cancel/all', params, cb)
-      .then(takeResNotifyInfo)
+      .then(_takeResNotify)
   }
 
   /**
@@ -1217,7 +1217,7 @@ class RESTv2 {
    */
   closeFunding (params, cb) {
     return this._makeAuthRequest('/auth/w/funding/close', params, cb)
-      .then(takeResNotifyInfo)
+      .then(_takeResNotify)
   }
 
   /**
@@ -1233,7 +1233,7 @@ class RESTv2 {
    */
   submitAutoFunding (params, cb) {
     return this._makeAuthRequest('/auth/w/funding/auto', params, cb)
-      .then(takeResNotifyInfo)
+      .then(_takeResNotify)
   }
 
   /**
@@ -1250,7 +1250,7 @@ class RESTv2 {
   transfer (params, cb) {
     params.currency_to = params.currencyTo
     return this._makeAuthRequest('/auth/w/transfer', params, cb)
-      .then(takeResNotifyInfo)
+      .then(_takeResNotify)
   }
 
   /**
@@ -1263,7 +1263,7 @@ class RESTv2 {
   getDepositAddress (params, cb) {
     params.op_renew = params.opRenew
     return this._makeAuthRequest('/auth/w/deposit/address', params, cb)
-      .then(takeResNotifyInfo)
+      .then(_takeResNotify)
   }
 
   /**
@@ -1276,7 +1276,7 @@ class RESTv2 {
    */
   withdraw (params, cb) {
     return this._makeAuthRequest('/auth/w/withdraw', params, cb)
-      .then(takeResNotifyInfo)
+      .then(_takeResNotify)
   }
 }
 

--- a/lib/rest2.js
+++ b/lib/rest2.js
@@ -84,7 +84,7 @@ class RESTv2 {
    */
   _takeResNotifyInfo (data) {
     const notification = new Notification(data)
-    return notification.notifyInfo
+    return { ...notification.notifyInfo, notification }
   }
 
   /**

--- a/lib/rest2.js
+++ b/lib/rest2.js
@@ -39,6 +39,16 @@ const BASE_TIMEOUT = 15000
 const API_URL = 'https://api.bitfinex.com'
 
 /**
+ * Parses response into notification object and then
+ * extracts the info element
+ * @param {Object} Notification.notify_info
+ */
+function takeResNotifyInfo (data) {
+  const notification = new Notification(data)
+  return { ...notification.notifyInfo, notification }
+}
+
+/**
  * Communicates with v2 of the Bitfinex HTTP API
  */
 class RESTv2 {
@@ -75,16 +85,6 @@ class RESTv2 {
 
     // Used for methods that are not yet implemented on REST v2
     this._rest1 = new RESTv1(opts)
-  }
-
-  /**
-   * Parses response into notification object and then
-   * extracts the info element
-   * @param {Object} Notification.notify_info
-   */
-  _takeResNotifyInfo (data) {
-    const notification = new Notification(data)
-    return { ...notification.notifyInfo, notification }
   }
 
   /**
@@ -1122,7 +1122,7 @@ class RESTv2 {
       .then((res) => {
         // 2 orders can be returned if OCO was used. But due to the interface
         // we can only return one. User should use getOrders instead
-        return this._takeResNotifyInfo(res)[0] || []
+        return takeResNotifyInfo(res)[0] || []
       })
   }
 
@@ -1134,7 +1134,7 @@ class RESTv2 {
    */
   updateOrder (changes, cb) {
     return this._makeAuthRequest('/auth/w/order/update', changes, cb)
-      .then(this._takeResNotifyInfo)
+      .then(takeResNotifyInfo)
   }
 
   /**
@@ -1145,7 +1145,7 @@ class RESTv2 {
    */
   cancelOrder (id, cb) {
     return this._makeAuthRequest('/auth/w/order/cancel', { id }, cb)
-      .then(this._takeResNotifyInfo)
+      .then(takeResNotifyInfo)
   }
 
   submitOrderMulti () {
@@ -1160,7 +1160,7 @@ class RESTv2 {
    */
   claimPosition (id, cb) {
     return this._makeAuthRequest('/auth/w/position/claim', { id }, cb)
-      .then(this._takeResNotifyInfo)
+      .then(takeResNotifyInfo)
   }
 
   /**
@@ -1181,7 +1181,7 @@ class RESTv2 {
     }
 
     return this._makeAuthRequest('/auth/w/funding/offer/submit', packet, cb)
-      .then(this._takeResNotifyInfo)
+      .then(takeResNotifyInfo)
   }
 
   /**
@@ -1192,7 +1192,7 @@ class RESTv2 {
    */
   cancelFundingOffer (id, cb) {
     return this._makeAuthRequest('/auth/w/funding/offer/cancel', { id }, cb)
-      .then(this._takeResNotifyInfo)
+      .then(takeResNotifyInfo)
   }
 
   /**
@@ -1204,7 +1204,7 @@ class RESTv2 {
    */
   cancelAllFundingOffers (params, cb) {
     return this._makeAuthRequest('/auth/w/funding/offer/cancel/all', params, cb)
-      .then(this._takeResNotifyInfo)
+      .then(takeResNotifyInfo)
   }
 
   /**
@@ -1217,7 +1217,7 @@ class RESTv2 {
    */
   closeFunding (params, cb) {
     return this._makeAuthRequest('/auth/w/funding/close', params, cb)
-      .then(this._takeResNotifyInfo)
+      .then(takeResNotifyInfo)
   }
 
   /**
@@ -1233,7 +1233,7 @@ class RESTv2 {
    */
   submitAutoFunding (params, cb) {
     return this._makeAuthRequest('/auth/w/funding/auto', params, cb)
-      .then(this._takeResNotifyInfo)
+      .then(takeResNotifyInfo)
   }
 
   /**
@@ -1250,7 +1250,7 @@ class RESTv2 {
   transfer (params, cb) {
     params.currency_to = params.currencyTo
     return this._makeAuthRequest('/auth/w/transfer', params, cb)
-      .then(this._takeResNotifyInfo)
+      .then(takeResNotifyInfo)
   }
 
   /**
@@ -1263,7 +1263,7 @@ class RESTv2 {
   getDepositAddress (params, cb) {
     params.op_renew = params.opRenew
     return this._makeAuthRequest('/auth/w/deposit/address', params, cb)
-      .then(this._takeResNotifyInfo)
+      .then(takeResNotifyInfo)
   }
 
   /**
@@ -1276,7 +1276,7 @@ class RESTv2 {
    */
   withdraw (params, cb) {
     return this._makeAuthRequest('/auth/w/withdraw', params, cb)
-      .then(this._takeResNotifyInfo)
+      .then(takeResNotifyInfo)
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-api-node-rest",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "Official Bitfinex REST v1 & v2 API interfaces",
   "engines": {
     "node": ">=7"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-api-node-rest",
-  "version": "2.0.8",
+  "version": "3.0.0",
   "description": "Official Bitfinex REST v1 & v2 API interfaces",
   "engines": {
     "node": ">=7"


### PR DESCRIPTION
### Description:
When adding the new V2 endpoints I added a method to extract the notification info from the response. This has proven to caused problems since the error messages for a failed withdraw are not passed on down to the user. This pull request changes it to just pass down the notification object

### Breaking changes:
- [x] All new v2 endpoints now return a notification object rather than an array/object

### New features:
None

### Fixes:
- [x] New v2 endpoints now return correct data, nothing is filtered out

### PR status:
- [x] Version bumped
- [x] Change-log updated
- ~~Tests added or updated~~
- ~~Documentation updated~~
