### PR TITLE
Fix auth transfer

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+# 2.0.6
+- Fix: Use correct endpoint for transfer
+
 # 2.0.5
 - RESTv2: add affCode support
 

--- a/lib/rest2.js
+++ b/lib/rest2.js
@@ -1237,7 +1237,7 @@ class RESTv2 {
    */
   transfer (params, cb) {
     params.currency_to = params.currencyTo
-    return this._makeAuthRequest('/auth/w/funding/auto', params, cb)
+    return this._makeAuthRequest('/auth/w/transfer', params, cb)
       .then(this._takeResNotifyInfo)
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-api-node-rest",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Official Bitfinex REST v1 & v2 API interfaces",
   "engines": {
     "node": ">=7"


### PR DESCRIPTION
### Description:
Orginal transfer function was calling to the wrong endpoint. This PR fixes that issue.

### Breaking changes:
None

### New features:
None

### Fixes:
- [x] rest v2: use correct endpoint for /transfer

### PR status:
- [x] Version bumped
- [x] Change-log updated
- ~~Tests added or updated~~
- ~~Documentation updated~~
