### PR TITLE
Add get order with ids

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+# 3.0.5
+- RESTv2: adds orderHistoryWithIds function
+
 # 3.0.4
 - RESTv2: added usesAgent() method
 - RESTv2: added getURL() method

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 # 3.0.5
 - RESTv2: adds orderHistoryWithIds function
+- RESTv2: adds activeOrdersWithIds function
 
 # 3.0.4
 - RESTv2: added usesAgent() method

--- a/docs/rest2.md
+++ b/docs/rest2.md
@@ -46,6 +46,7 @@ Communicates with v2 of the Bitfinex HTTP API
     * [.walletsHistory(end, currency, cb)](#RESTv2+walletsHistory) ⇒ <code>Promise</code>
     * [.userInfo(cb)](#RESTv2+userInfo) ⇒ <code>Promise</code>
     * [.activeOrders(cb)](#RESTv2+activeOrders) ⇒ <code>Promise</code>
+    * [.activeOrdersWithIds(ids, cb)](#RESTv2+activeOrdersWithIds) ⇒ <code>Promise</code>
     * [.movements(ccy, start, end, limit, cb)](#RESTv2+movements) ⇒ <code>Promise</code>
     * [.ledgers(filters, start, end, limit, cb)](#RESTv2+ledgers) ⇒ <code>Promise</code>
     * [.orderHistory(symbol, start, end, limit, cb)](#RESTv2+orderHistory) ⇒ <code>Promise</code>
@@ -386,12 +387,24 @@ Get a list of valid currencies ids, full names, pool and explorer
 
 ### resTv2.activeOrders(cb) ⇒ <code>Promise</code>
 **Kind**: instance method of [<code>RESTv2</code>](#RESTv2)  
-**Returns**: <code>Promise</code> - p  
+**Returns**: <code>Promise</code> - p
 **See**: https://docs.bitfinex.com/v2/reference#rest-auth-orders  
 
 | Param | Type |
 | --- | --- |
-| cb | <code>Method</code> | 
+| cb | <code>Method</code> |
+
+<a name="RESTv2+activeOrdersWithIds"></a>
+
+### resTv2.activeOrdersWithIds(ids, cb) ⇒ <code>Promise</code>
+**Kind**: instance method of [<code>RESTv2</code>](#RESTv2)
+**Returns**: <code>Promise</code> - p  
+**See**: https://docs.bitfinex.com/v2/reference#rest-auth-orders
+
+| Param | Type | Description |
+| --- | --- | --- |
+| ids | <code>array</code> | order ids |
+| cb | <code>Method</code> |  |
 
 <a name="RESTv2+movements"></a>
 

--- a/docs/rest2.md
+++ b/docs/rest2.md
@@ -49,6 +49,7 @@ Communicates with v2 of the Bitfinex HTTP API
     * [.movements(ccy, start, end, limit, cb)](#RESTv2+movements) ⇒ <code>Promise</code>
     * [.ledgers(filters, start, end, limit, cb)](#RESTv2+ledgers) ⇒ <code>Promise</code>
     * [.orderHistory(symbol, start, end, limit, cb)](#RESTv2+orderHistory) ⇒ <code>Promise</code>
+    * [.orderHistoryWithIds(ids, cb)](#RESTv2+orderHistoryWithIds) ⇒ <code>Promise</code>
     * [.orderTrades(symbol, start, end, limit, orderID, cb)](#RESTv2+orderTrades) ⇒ <code>Promise</code>
     * [.positions(cb)](#RESTv2+positions) ⇒ <code>Promise</code>
     * [.positionsHistory(start, end, limit, cb)](#RESTv2+positionsHistory) ⇒ <code>Promise</code>
@@ -436,6 +437,18 @@ Get a list of valid currencies ids, full names, pool and explorer
 | end | <code>number</code> | <code></code> |  |
 | limit | <code>number</code> | <code></code> |  |
 | cb | <code>Method</code> |  |  |
+
+<a name="RESTv2+orderHistoryWithIds"></a>
+
+### resTv2.orderHistoryWithIds(ids, cb) ⇒ <code>Promise</code>
+**Kind**: instance method of [<code>RESTv2</code>](#RESTv2)  
+**Returns**: <code>Promise</code> - p  
+**See**: https://docs.bitfinex.com/v2/reference#orders-history  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| ids | <code>array</code> | order ids |
+| cb | <code>Method</code> |  |
 
 <a name="RESTv2+orderTrades"></a>
 

--- a/lib/rest2.js
+++ b/lib/rest2.js
@@ -751,6 +751,17 @@ class RESTv2 {
   }
 
   /**
+   * @param {array?} ids - order ids
+   * @param {Method} cb
+   * @return {Promise} p
+   * @see https://docs.bitfinex.com/v2/reference#orders-history
+   */
+  orderHistoryWithIds (ids = [], cb) {
+    const url = '/auth/r/orders/hist'
+    return this._makeAuthRequest(url, { id: ids }, cb, Order)
+  }
+
+  /**
    * @param {string} symbol
    * @param {number} start
    * @param {number} end

--- a/lib/rest2.js
+++ b/lib/rest2.js
@@ -690,6 +690,17 @@ class RESTv2 {
   }
 
   /**
+   * @param {array?} ids - order ids
+   * @param {Method} cb
+   * @return {Promise} p
+   * @see https://docs.bitfinex.com/v2/reference#rest-auth-orders
+   */
+  activeOrdersWithIds (ids = [], cb) {
+    const url = '/auth/r/orders'
+    return this._makeAuthRequest(url, { id: ids }, cb, Order)
+  }
+
+  /**
    * @param {string?} ccy - i.e. ETH
    * @param {number?} start
    * @param {number?} end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-api-node-rest",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "Official Bitfinex REST v1 & v2 API interfaces",
   "engines": {
     "node": ">=7"


### PR DESCRIPTION
### Description:
/order/hist endpoint now allows the client to specify a list of Id's. This pull request adds that functionality in the form of a new function.

### Breaking changes:
- None

### New features:
- [x] function: orderHistoryWithIds
- [x] function: activeOrdersWithIds

### Fixes:
- None

### PR status:
- [x] Version bumped
- [x] Change-log updated
- [x] Documentation updated
