### PR TITLE
Support cancel cid

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+# 3.0.6
+- RESTv2: adds cancelOrderWithCid function
+- RESTv2: adds cancelOrderWithDate function
+
 # 3.0.5
 - RESTv2: adds orderHistoryWithIds function
 - RESTv2: adds activeOrdersWithIds function

--- a/docs/rest2.md
+++ b/docs/rest2.md
@@ -84,6 +84,8 @@ Communicates with v2 of the Bitfinex HTTP API
     * [.submitOrder(order, cb)](#RESTv2+submitOrder)
     * [.updateOrder(order, cb)](#RESTv2+updateOrder)
     * [.cancelOrder(id, cb)](#RESTv2+cancelOrder)
+    * [.cancelOrderWithCid(cid, cb)](#RESTv2+cancelOrderWithCid)
+    * [.cancelOrderWithDate(cid, cb)](#RESTv2+cancelOrderWithDate)
     * [.claimPosition(id, cb)](#RESTv2+claimPosition)
     * [.submitFundingOffer(offer, cb)](#RESTv2+submitFundingOffer)
     * [.cancelFundingOffer(id, cb)](#RESTv2+cancelFundingOffer)
@@ -387,19 +389,19 @@ Get a list of valid currencies ids, full names, pool and explorer
 
 ### resTv2.activeOrders(cb) ⇒ <code>Promise</code>
 **Kind**: instance method of [<code>RESTv2</code>](#RESTv2)  
-**Returns**: <code>Promise</code> - p
+**Returns**: <code>Promise</code> - p  
 **See**: https://docs.bitfinex.com/v2/reference#rest-auth-orders  
 
 | Param | Type |
 | --- | --- |
-| cb | <code>Method</code> |
+| cb | <code>Method</code> | 
 
 <a name="RESTv2+activeOrdersWithIds"></a>
 
 ### resTv2.activeOrdersWithIds(ids, cb) ⇒ <code>Promise</code>
-**Kind**: instance method of [<code>RESTv2</code>](#RESTv2)
+**Kind**: instance method of [<code>RESTv2</code>](#RESTv2)  
 **Returns**: <code>Promise</code> - p  
-**See**: https://docs.bitfinex.com/v2/reference#rest-auth-orders
+**See**: https://docs.bitfinex.com/v2/reference#rest-auth-orders  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -903,6 +905,30 @@ Cancel existing order
 | --- | --- | --- |
 | id | <code>int</code> | order id |
 | cb | <code>Method</code> |  |
+
+<a name="RESTv2+cancelOrderWithCid"></a>
+
+### resTv2.cancelOrderWithCid(cid, cb)
+Cancel existing order using the cID
+
+**Kind**: instance method of [<code>RESTv2</code>](#RESTv2)  
+
+| Param | Type |
+| --- | --- |
+| cid | <code>int</code> | 
+| cb | <code>Method</code> | 
+
+<a name="RESTv2+cancelOrderWithDate"></a>
+
+### resTv2.cancelOrderWithDate(cid, cb)
+Cancel existing order using the cID date
+
+**Kind**: instance method of [<code>RESTv2</code>](#RESTv2)  
+
+| Param | Type |
+| --- | --- |
+| cid | <code>int</code> | 
+| cb | <code>Method</code> | 
 
 <a name="RESTv2+claimPosition"></a>
 

--- a/lib/rest2.js
+++ b/lib/rest2.js
@@ -1210,6 +1210,28 @@ class RESTv2 {
       .then(_takeResNotify)
   }
 
+  /**
+   * Cancel existing order using the cID
+   *
+   * @param {int} cid
+   * @param {Method} cb
+   */
+  cancelOrderWithCid (cid, cb) {
+    return this._makeAuthRequest('/auth/w/order/cancel', { cid }, cb)
+      .then(_takeResNotify)
+  }
+
+  /**
+   * Cancel existing order using the cID date
+   *
+   * @param {int} cid
+   * @param {Method} cb
+   */
+  cancelOrderWithDate (date, cb) {
+    return this._makeAuthRequest('/auth/w/order/cancel', { cid_date: date }, cb)
+      .then(_takeResNotify)
+  }
+
   submitOrderMulti () {
     return Promise.reject(new Error('Not implemented - requires work on WS as well'))
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-api-node-rest",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "Official Bitfinex REST v1 & v2 API interfaces",
   "engines": {
     "node": ">=7"


### PR DESCRIPTION
### Description:
The user was not originally able to pass their CID when cancelling an order. This PR adds 2 new functions which take in cID and CID_date

### Breaking changes:
None

### New features:
- [x] RESTv2: adds cancelOrderWithCid function
- [x] RESTv2: adds cancelOrderWithDate functi

### Fixes:
None

### PR status:
- [x] Version bumped
- [x] Change-log updated
- [x] Documentation updated
