### PR TITLE
(fix) REST2 now correctly uses affiliate code in submitOrder

### DIFF
--- a/lib/rest2.js
+++ b/lib/rest2.js
@@ -1188,7 +1188,7 @@ class RESTv2 {
         packet.meta = {}
       }
 
-      packet.meta.aff_code = packet.meta.aff_code || this.affCode // eslint-disable-line
+      packet.meta.aff_code = packet.meta.aff_code || this._affCode // eslint-disable-line
     }
 
     return this._makeAuthRequest('/auth/w/order/submit', packet, cb)


### PR DESCRIPTION
### Description:
Due to a typo, even if affiliate code was set, it was always passed to _makeAuthRequest as undefined

### Fixes:
- Orders placed using REST will now be placed with affiliate code

### PR status:
- [ ] Version bumped
- [ ] Change-log updated
- [ ] Tests added or updated
- [ ] Documentation updated
