### PR TITLE
fix type of amount transfer function

### DIFF
--- a/lib/rest2.js
+++ b/lib/rest2.js
@@ -1573,7 +1573,7 @@ class RESTv2 {
    * Execute a balance transfer between wallets
    *
    * @param {object} params - parameters
-   * @param {number} params.amount - amount to transfer
+   * @param {string} params.amount - amount to transfer
    * @param {string} params.from - wallet from
    * @param {string} params.to - wallet to
    * @param {string} params.currency - currency from


### PR DESCRIPTION
type number return 500 error with invalid amount

### Description:
...

### Breaking changes:
- [ ]

### New features:
- [ ]

### Fixes:
- fixed wrong type in jsdocs in transfer method

### PR status:
- [ ] Version bumped
- [ ] Change-log updated
- [ ] Tests added or updated
- [ ] Documentation updated
