### PR TITLE
Add missing parameter on calcAvailableBalance

### DIFF
--- a/lib/rest2.js
+++ b/lib/rest2.js
@@ -1050,16 +1050,18 @@ class RESTv2 {
    * @param {string} dir - dir
    * @param {number} rate - rate
    * @param {string} type - type
+   * @param {string} lev - lev
    * @param {Function} [cb] - callback
    * @returns {Promise} p
    * @see https://docs.bitfinex.com/v2/reference#rest-auth-calc-bal-avail
    */
-  calcAvailableBalance (symbol = 'tBTCUSD', dir, rate, type, cb) {
+  calcAvailableBalance (symbol = 'tBTCUSD', dir, rate, type, lev, cb) {
     return this._makeAuthRequest('/auth/calc/order/avail', {
       symbol,
       dir,
       rate,
-      type
+      type,
+      lev
     }, cb)
   }
 


### PR DESCRIPTION
### Description:
Missing parameter : lev
Added a missing parameter, according to the doc : https://docs.bitfinex.com/reference/rest-auth-calc-order-avail

### Breaking changes:
- [ ]

### New features:
- [ ]

### Fixes:
- [ ]

### PR status:
- [ ] Version bumped
- [ ] Change-log updated
- [ ] Tests added or updated
- [ ] Documentation updated
