### PR TITLE
add recurring algo order methods

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+# 4.6.1
+- RESTv2: add submitRecurringAlgoOrder method
+- RESTv2: add getRecurringAlgoOrder method
+- RESTv2: add updateRecurringAlgoOrder method
+- RESTv2: add cancelRecurringAlgoOrder method
+- RESTv2: add getRecurringAlgoOrders method
+
 # 4.6.0
 - RESTv2: add ability to set timeout for private requests and change value in extra option
 

--- a/lib/rest2.js
+++ b/lib/rest2.js
@@ -1319,6 +1319,92 @@ class RESTv2 {
   }
 
   /**
+   * Submit recurring algo order
+   *
+   * @param {object} order
+   * @param {string} order.alias
+   * @param {string} order._symbol
+   * @param {string} order.currency
+   * @param {'buy'|'sell'} order.action
+   * @param {number} order.amount
+   * @param {'daily'|'weekly'|'monthly'} order.recurrence
+   * @param {Date} [order.startedAt]
+   * @param {Date} [order.endedAt] - if it is set then `endless` shouldn't be set
+   * @param {boolean} [order.endless] - if it is set then `endedAt` shouldn't be set
+   * @param {Function} [cb] - callback
+   * @returns {Promise} p
+   */
+  submitRecurringAlgoOrder (order, cb) {
+    return this._makeAuthRequest('/auth/w/ext/recurring-ao/create', order, cb)
+  }
+
+  /**
+   * Get recurring algo order by id
+   *
+   * @param {string} algoOrderId
+   * @param {Function} [cb] - callback
+   * @returns {Promise} p
+   */
+  getRecurringAlgoOrder (algoOrderId, cb) {
+    return this._makeAuthRequest(`/auth/r/ext/recurring-ao/detail/${algoOrderId}`, {}, cb)
+  }
+
+  /**
+   * Update recurring algo order
+   *
+   * @param {object} order
+   * @param {string} order.algoOrderId
+   * @param {string} [order.alias]
+   * @param {string} [order._symbol]
+   * @param {string} [order.currency]
+   * @param {'buy'|'sell'} [order.action]
+   * @param {number} [order.amount]
+   * @param {'daily'|'weekly'|'monthly'} [order.recurrence]
+   * @param {Date} [order.endedAt] - if it is set then `endless` shouldn't be set
+   * @param {boolean} [order.endless] - if it is set then `endedAt` shouldn't be set
+   * @param {Function} [cb] - callback
+   * @returns {Promise<boolean>}
+   */
+  updateRecurringAlgoOrder (order, cb) {
+    return this._makeAuthRequest(`/auth/w/ext/recurring-ao/update/${order.algoOrderId}`, order, cb)
+  }
+
+  /**
+   * Cancel recurring algo order
+   *
+   * @param {string} algoOrderId
+   * @param {Function} [cb] - callback
+   * @returns {Promise<boolean>}
+   */
+  cancelRecurringAlgoOrder (algoOrderId, cb) {
+    return this._makeAuthRequest(`/auth/w/ext/recurring-ao/cancel/${algoOrderId}`, {}, cb)
+  }
+
+  /**
+   * Get recurring algo orders
+   *
+   * @param {object} args
+   * @param {number} [args.page]
+   * @param {number} [args.limit]
+   * @param {string} [args.sortField]
+   * @param {'asc'|'desc'} [args.sortOrder]
+   * @param {object} [args.filter]
+   * @param {string | string[]} [args.filter.status] - Comma separated statuses or array of statuses
+   * @param {string} [args.filter.alias]
+   * @param {Date} [args.filter.startedAt]
+   * @param {Date} [args.filter.endedAt]
+   * @param {boolean} [args.filter.endless]
+   * @param {'daily'|'weekly'|'monthly'} [args.filter.recurrence]
+   * @param {'buy'|'sell'} [args.filter.action]
+   * @param {string} [args.filter._symbol]
+   * @param {string} [args.filter.currency]
+   * @param {Function} [cb] - callback
+   */
+  getRecurringAlgoOrders (args, cb) {
+    return this._makeAuthRequest('/auth/r/ext/recurring-ao/list', args, cb)
+  }
+
+  /**
    * Update existing order
    *
    * @param {object} changes - updates to order

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-api-node-rest",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "description": "Official Bitfinex REST v1 & v2 API interfaces",
   "engines": {
     "node": ">=8.3.0"


### PR DESCRIPTION
### Description:
Add recurring algo order APIs

- `submitRecurringAlgoOrder (order, cb)`
- `getRecurringAlgoOrder (algoOrderId, cb)`
- `updateRecurringAlgoOrder (order, cb)`
- `cancelRecurringAlgoOrder (algoOrderId, cb)`
- `getRecurringAlgoOrders (args, cb)`

### Breaking changes:
- [ ]

### New features:
- [x] Add recurring Algo Order APIs

### Fixes:
- [ ]

### PR status:
- [ ] Version bumped
- [ ] Change-log updated
- [ ] Tests added or updated
- [ ] Documentation updated
