### PR TITLE
Movements - Add array of movements ids to the request body

### DIFF
--- a/lib/rest2.js
+++ b/lib/rest2.js
@@ -751,16 +751,17 @@ class RESTv2 {
    * @param {number} [start] - query start
    * @param {number} [end] - query end
    * @param {number} [limit] - query limit, default 25
+   * @param {Array?} [id] - Optional array of deposit/withdrawal ids
    * @param {Function} [cb] - callback
    * @returns {Promise} p
    * @see https://docs.bitfinex.com/v2/reference#movements
    */
-  movements (ccy, start = null, end = Date.now(), limit = 25, cb) {
+  movements (ccy, start = null, end = Date.now(), limit = 25, id, cb) {
     const url = ccy
       ? `/auth/r/movements/${ccy}/hist`
       : '/auth/r/movements/hist'
 
-    return this._makeAuthRequest(url, { start, end, limit }, cb, Movement)
+    return this._makeAuthRequest(url, { start, end, limit, id }, cb, Movement)
   }
 
   /**

--- a/lib/rest2.js
+++ b/lib/rest2.js
@@ -756,7 +756,13 @@ class RESTv2 {
    * @returns {Promise} p
    * @see https://docs.bitfinex.com/v2/reference#movements
    */
-  movements (ccy, start = null, end = Date.now(), limit = 25, id, cb) {
+  movements (ccy, start = null, end = Date.now(), limit = 25, id = [], cb) {
+    // backward compatibility
+    if (typeof id === 'function') {
+      cb = id
+      id = undefined
+    }
+
     const url = ccy
       ? `/auth/r/movements/${ccy}/hist`
       : '/auth/r/movements/hist'

--- a/lib/rest2.js
+++ b/lib/rest2.js
@@ -751,7 +751,7 @@ class RESTv2 {
    * @param {number} [start] - query start
    * @param {number} [end] - query end
    * @param {number} [limit] - query limit, default 25
-   * @param {Array?} [id] - Optional array of deposit/withdrawal ids
+   * @param {Array<number>} [id] - Optional array of deposit/withdrawal ids
    * @param {Function} [cb] - callback
    * @returns {Promise} p
    * @see https://docs.bitfinex.com/v2/reference#movements


### PR DESCRIPTION
### Description:
I was trying to query a movement by id but I noticed the array of ids was missing.
https://docs.bitfinex.com/reference/rest-auth-movements

### Breaking changes:
- [ ]

### New features:
- [ ]

### Fixes:
- [x] Add array of movements ids to the request body

### PR status:
- [ ] Version bumped
- [ ] Change-log updated
- [ ] Tests added or updated
- [ ] Documentation updated
