### PR TITLE
Endpoint to get list of atomic orders executed by Recurring AO

### DIFF
--- a/lib/rest2.js
+++ b/lib/rest2.js
@@ -2348,6 +2348,24 @@ class RESTv2 {
   getRecurringAlgoOrders (params = {}, cb = null) {
     return this._makeAuthRequest('/auth/r/ext/recurring-ao/list', params, cb)
   }
+
+  /**
+   * Get list of orders executed by Recurring AO
+   *
+   * @param {object} params               - search query params
+   * @param {number} [params.algoOrderId] - algo order id to search
+   * @param {number} [params.page]        - search query results page number
+   * @param {number} [params.limit]       - search query results limit
+   * @param {string} [params.sortField]   - search query sort field
+   * @param {'asc'|'desc'} [params.sortOrder] - search query sort order
+   * @param {object} [params.filter]          - object with filter params
+   * @param {string | string[]} [params.filter.status] - Comma separated statuses or array of statuses
+   * @param {Function} [cb] - legacy callback
+   * @returns {Promise} p
+   */
+  getRecurringAoOrders (params = {}, cb = null) {
+    return this._makeAuthRequest('/auth/r/ext/recurring-ao/order/list', params, cb)
+  }
 }
 
 RESTv2.url = API_URL


### PR DESCRIPTION
### Description:
Endpoint to get list of atomic orders executed by Recurring AO

### Breaking changes:
- [ ]

### New features:
- Recurring AO executed orders

### Fixes:
- [ ]

### PR status:
- [ ] Version bumped
- [ ] Change-log updated
- [ ] Tests added or updated
- [ ] Documentation updated
