### PR TITLE
add abort controller

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+# 8.0.0
+- RESTv2: add abort controller
+
 # 7.0.0
 - RESTv2: remove pay endpoints
 

--- a/lib/rest2.js
+++ b/lib/rest2.js
@@ -116,11 +116,10 @@ class RESTv2 {
    * @private
    */
   _checkOpts (opts) {
-    if (
-      !_isNil(opts.timeout) &&
-      !_isInteger(opts.timeout)
-    ) {
-      throw new Error('ERR_TIMEOUT_DATA_TYPE_ERROR')
+    if (!_isNil(opts.timeout)) {
+      if (!_isInteger(opts.timeout) || opts.timeout < 0) {
+        throw new Error('ERR_TIMEOUT_DATA_TYPE_ERROR')
+      }
     }
   }
 
@@ -140,16 +139,15 @@ class RESTv2 {
 
   async _request (url, reqOpts, transformer, cb) {
     let timeoutId
-    reqOpts.timeout = 0
 
-    if (this._timeout > 0) {
+    if (reqOpts.timeout > 0) {
       const controller = new AbortController()
       reqOpts.signal = controller.signal
-      timeoutId = setTimeout(() => controller.abort(), this._timeout)
+      timeoutId = setTimeout(() => controller.abort(), reqOpts.timeout)
     }
 
     try {
-      const resp = await fetch(url, reqOpts)
+      const resp = await fetch(url, { ...reqOpts, timeout: 0 })
       if (timeoutId) clearTimeout(timeoutId)
 
       const raw = await resp.text()
@@ -217,6 +215,7 @@ class RESTv2 {
 
     const reqOpts = {
       method: 'POST',
+      timeout: this._timeout,
       headers: {
         'content-type': 'application/json',
         'bfx-nonce': n,
@@ -246,6 +245,7 @@ class RESTv2 {
 
     const reqOpts = {
       method: 'GET',
+      timeout: this._timeout,
       agent: this._agent
     }
 
@@ -269,6 +269,7 @@ class RESTv2 {
 
     const reqOpts = {
       method: 'POST',
+      timeout: this._timeout,
       headers: {
         'content-type': 'application/json'
       },

--- a/lib/rest2.js
+++ b/lib/rest2.js
@@ -140,11 +140,12 @@ class RESTv2 {
 
   async _request (url, reqOpts, transformer, cb) {
     let timeoutId
+    reqOpts.timeout = 0
 
-    if (reqOpts.timeout > 0) {
+    if (this._timeout > 0) {
       const controller = new AbortController()
       reqOpts.signal = controller.signal
-      timeoutId = setTimeout(() => controller.abort(), reqOpts.timeout)
+      timeoutId = setTimeout(() => controller.abort(), this._timeout)
     }
 
     try {
@@ -163,7 +164,7 @@ class RESTv2 {
       if (timeoutId) clearTimeout(timeoutId)
 
       if (err.name === 'AbortError') {
-        const timeoutErr = new Error(`request timed out after ${reqOpts.timeout}ms`)
+        const timeoutErr = new Error(`request timed out after ${this._timeout}ms`)
         return this._cb(timeoutErr, null, cb)
       }
 
@@ -216,7 +217,6 @@ class RESTv2 {
 
     const reqOpts = {
       method: 'POST',
-      timeout: this._timeout,
       headers: {
         'content-type': 'application/json',
         'bfx-nonce': n,
@@ -246,7 +246,6 @@ class RESTv2 {
 
     const reqOpts = {
       method: 'GET',
-      timeout: this._timeout,
       agent: this._agent
     }
 
@@ -270,7 +269,6 @@ class RESTv2 {
 
     const reqOpts = {
       method: 'POST',
-      timeout: this._timeout,
       headers: {
         'content-type': 'application/json'
       },

--- a/lib/rest2.js
+++ b/lib/rest2.js
@@ -139,16 +139,34 @@ class RESTv2 {
   }
 
   async _request (url, reqOpts, transformer, cb) {
+    let timeoutId
+
+    if (reqOpts.timeout > 0 && typeof AbortController !== 'undefined') {
+      const controller = new AbortController()
+      reqOpts.signal = controller.signal
+      timeoutId = setTimeout(() => controller.abort(), reqOpts.timeout)
+    }
+
     try {
       const resp = await fetch(url, reqOpts)
+      if (timeoutId) clearTimeout(timeoutId)
+
       const raw = await resp.text()
       if (!resp.ok) {
         const err = this._apiError(resp, raw)
         throw err
       }
+
       const json = JSON.parse(raw)
       return this._response(json, transformer, cb)
     } catch (err) {
+      if (timeoutId) clearTimeout(timeoutId)
+
+      if (err.name === 'AbortError') {
+        const timeoutErr = new Error(`request timed out after ${reqOpts.timeout}ms`)
+        return this._cb(timeoutErr, null, cb)
+      }
+
       return this._cb(err, null, cb)
     }
   }

--- a/lib/rest2.js
+++ b/lib/rest2.js
@@ -141,7 +141,7 @@ class RESTv2 {
   async _request (url, reqOpts, transformer, cb) {
     let timeoutId
 
-    if (reqOpts.timeout > 0 && typeof AbortController !== 'undefined') {
+    if (reqOpts.timeout > 0) {
       const controller = new AbortController()
       reqOpts.signal = controller.signal
       timeoutId = setTimeout(() => controller.abort(), reqOpts.timeout)

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "7.0.0",
   "description": "Official Bitfinex REST v1 & v2 API interfaces",
   "engines": {
-    "node": ">=8.3.0"
+    "node": ">=16.0.0"
   },
   "main": "./index.js",
   "husky": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-api-node-rest",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "description": "Official Bitfinex REST v1 & v2 API interfaces",
   "engines": {
     "node": ">=16.0.0"

--- a/test/lib/rest-2-integration.js
+++ b/test/lib/rest-2-integration.js
@@ -359,4 +359,36 @@ describe('RESTv2 integration (mock server) tests', () => {
     const order = await r.closePosition({ position_id: 145287699 })
     assert.deepStrictEqual(order, orderRes)
   })
+
+  it('timeouts on a long-running request', async () => {
+    srv = new MockRESTv2Server({ listen: false })
+    srv._apiServer.get('/v2/slow', (req, res) => {
+      setTimeout(() => {
+        res.json([42])
+      }, 300)
+    })
+    srv.listen()
+
+    const r = getTestREST2({ timeout: 100 })
+    try {
+      await r._makePublicRequest('/slow')
+      assert.fail('should have timed out')
+    } catch (err) {
+      assert.strictEqual(err.message, 'request timed out after 100ms')
+    }
+  })
+
+  it('succeeds when request is within timeout', async () => {
+    srv = new MockRESTv2Server({ listen: false })
+    srv._apiServer.get('/v2/fast', (req, res) => {
+      setTimeout(() => {
+        res.json([42])
+      }, 100)
+    })
+    srv.listen()
+
+    const r = getTestREST2({ timeout: 200 })
+    const res = await r._makePublicRequest('/fast')
+    assert.deepStrictEqual(res, [42])
+  })
 })


### PR DESCRIPTION
### Description:
use abort controller to avoid infinite response await for cases when connection could not be established
replace timeout logic with AbortController, see [docs](https://github.com/node-fetch/node-fetch/blob/v2.6.9/README.md#options)

### Breaking changes:
- [X] minimal node version set to 16

### New features:
- [ ]

### Fixes:
- [X] infinite response awaiting issue when server is down

### PR status:
- [X] Version bumped
- [X] Change-log updated
- [ ] Tests added or updated
- [ ] Documentation updated
